### PR TITLE
Fixed following error which doesn't appear in a normal game, but can be

### DIFF
--- a/CraftManager.cs
+++ b/CraftManager.cs
@@ -42,7 +42,7 @@ namespace CraftManager
         internal static GUISkin alt_skin = null;
 
         //other
-        public static string ksp_root = Directory.GetParent(KSPUtil.ApplicationRootPath).FullName;
+        public static string ksp_root { get { return Directory.GetParent(KSPUtil.ApplicationRootPath).FullName; } }
         public static string status_info = "";
         
 


### PR DESCRIPTION
seen when in a debug version:
UnityException: get_dataPath is not allowed to be called from a
MonoBehaviour constructor (or instance field initializer), call it in
Awake or Start instead. Called from MonoBehaviour 'CraftManager' on game
object 'CraftManager'.
See "Script Serialization" page in the Unity Manual for further details.
  at (wrapper managed-to-native) UnityEngine.Application.get_dataPath()
    at KSPUtil.get_ApplicationRootPath () [0x0001d] in
    <9d71e4043e394d78a6cf9193ad011698>:0
      at CraftManager.CraftManager..cctor () [0x00049] in
      <8b61a4f45bb64fb591febc58234adb97>:0
      Rethrow as TypeInitializationException: The type initializer for
      'CraftManager.CraftManager' threw an exception.